### PR TITLE
feat(ui): 统一标签页组件样式并优化视觉效果

### DIFF
--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeKatex from 'rehype-katex';
+import remarkMath from 'remark-math';
+import 'katex/dist/katex.min.css';
+
+type MarkdownPreviewProps = {
+  value?: string;
+  className?: string;
+};
+
+const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({ value = '', className = '' }) => {
+  return (
+    <div className={`uiux-md-preview ${className}`}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, remarkMath]}
+        rehypePlugins={[rehypeKatex]}
+        components={{
+          img: () => null,
+          pre: () => null,
+          table: () => null,
+          h1: ({ children }) => <p className="uiux-md-block uiux-md-heading">{children}</p>,
+          h2: ({ children }) => <p className="uiux-md-block uiux-md-heading">{children}</p>,
+          h3: ({ children }) => <p className="uiux-md-block uiux-md-heading">{children}</p>,
+          h4: ({ children }) => <p className="uiux-md-block uiux-md-heading">{children}</p>,
+          p: ({ children }) => <p className="uiux-md-block">{children}</p>,
+          ul: ({ children }) => <ul className="uiux-md-block uiux-md-list">{children}</ul>,
+          ol: ({ children }) => <ol className="uiux-md-block uiux-md-list">{children}</ol>,
+          li: ({ children }) => <span className="uiux-md-li">{children}</span>,
+          code({ inline, children, ...props }) {
+            if (!inline) return null;
+            return (
+              <code className="uiux-md-code" {...props}>
+                {children}
+              </code>
+            );
+          },
+        }}
+      >
+        {value}
+      </ReactMarkdown>
+    </div>
+  );
+};
+
+export default MarkdownPreview;

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,7 +1,7 @@
-import { Tabs } from "antd";
 import MainLayout from "../../layouts/MainLayout.tsx";
 import { Outlet, useNavigate, useLocation } from "react-router-dom";
 import { useEffect, useState } from "react";
+import "../../styles/uiuxpro.css";
 
 function AdminPageMain() {
 
@@ -55,17 +55,24 @@ function AdminPageMain() {
     return (
         <>
             <MainLayout>
-                <Tabs
-                    activeKey={activeKey}
-                    centered
-                    items={adminPageTabItems}
-                    onChange={(key) => {
-                        const path = adminPageTabItems.find(item => item.key === key)?.path;
-                        if (path) {
-                            navigate(path);
-                        }
-                    }}
-                />
+                <div className="uiux-scope" style={{ marginBottom: 12 }}>
+                    <nav className="uiux-tabs uiux-tabs-wrap" aria-label="管理后台导航">
+                        {adminPageTabItems.map(item => (
+                            <button
+                                key={item.key}
+                                type="button"
+                                role="tab"
+                                aria-selected={activeKey === item.key}
+                                className={`uiux-tab ${activeKey === item.key ? 'uiux-tab-active' : ''}`}
+                                onClick={() => {
+                                    if (item.path) navigate(item.path);
+                                }}
+                            >
+                                {item.label}
+                            </button>
+                        ))}
+                    </nav>
+                </div>
                 <Outlet />
             </MainLayout>
 

--- a/src/pages/index/Main/Main.css
+++ b/src/pages/index/Main/Main.css
@@ -11,41 +11,39 @@
 
 /* Glassmorphism Welcome Banner */
 .welcome-banner {
-    background: linear-gradient(135deg, #16a34a 0%, #059669 100%);
+    background:
+        radial-gradient(180px 90px at 20% 15%, rgba(22, 163, 74, 0.18), rgba(22, 163, 74, 0) 70%),
+        radial-gradient(220px 110px at 85% 140%, rgba(5, 150, 105, 0.14), rgba(5, 150, 105, 0) 60%),
+        linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(248, 250, 252, 0.92));
     border-radius: 24px;
-    padding: 40px;
+    padding: 32px;
     display: flex;
     justify-content: space-between;
     align-items: center;
     margin-bottom: 32px;
-    color: white;
-    box-shadow: 0 10px 30px -10px rgba(22, 163, 74, 0.5);
+    color: var(--uiux-text);
+    box-shadow: 0 10px 30px -18px rgba(15, 23, 42, 0.22);
     position: relative;
     overflow: hidden;
+    border: 1px solid rgba(226, 232, 240, 0.9);
 }
 
 .welcome-banner::before {
     content: '';
     position: absolute;
-    top: -50%;
-    left: -20%;
-    width: 200px;
-    height: 200px;
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 50%;
-    filter: blur(50px);
+    inset: 0;
+    background:
+        repeating-linear-gradient(135deg, rgba(22, 163, 74, 0.06) 0 6px, rgba(22, 163, 74, 0) 6px 12px);
+    opacity: 0.8;
+    pointer-events: none;
 }
 
 .welcome-banner::after {
     content: '';
     position: absolute;
-    bottom: -50%;
-    right: -20%;
-    width: 300px;
-    height: 300px;
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 50%;
-    filter: blur(60px);
+    inset: 0;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85);
+    pointer-events: none;
 }
 
 .welcome-content {
@@ -59,13 +57,15 @@
     font-size: 32px;
     font-weight: 700;
     letter-spacing: -0.5px;
+    color: #0f172a;
 }
 
 .welcome-content p {
     margin: 0;
-    opacity: 0.95;
+    opacity: 1;
     font-size: 16px;
     font-weight: 500;
+    color: #475569;
 }
 
 .welcome-actions {
@@ -90,27 +90,27 @@
 }
 
 .btn-primary {
-    background: white;
-    color: #16a34a;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    background: var(--uiux-primary);
+    color: white;
+    box-shadow: 0 10px 22px -18px rgba(22, 163, 74, 0.85);
 }
 
 .btn-primary:hover {
-    background: #f0fdf4;
-    transform: translateY(-2px);
-    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+    background: var(--uiux-primary-hover);
+    transform: translateY(-1px);
 }
 
 .btn-secondary {
-    background: rgba(255, 255, 255, 0.15);
-    color: white;
-    backdrop-filter: blur(10px);
-    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: rgba(241, 245, 249, 0.7);
+    color: #0f172a;
+    border: 1px solid rgba(226, 232, 240, 0.95);
 }
 
 .btn-secondary:hover {
-    background: rgba(255, 255, 255, 0.25);
-    transform: translateY(-2px);
+    background: rgba(240, 253, 244, 0.9);
+    border-color: rgba(22, 163, 74, 0.28);
+    color: var(--uiux-primary);
+    transform: translateY(-1px);
 }
 
 /* Study Plans Grid */
@@ -185,43 +185,20 @@
 
 /* Tabs */
 .content-tabs {
-    display: flex;
-    gap: 24px;
     margin-bottom: 24px;
-    border-bottom: 1px solid #e2e8f0;
-    padding-bottom: 2px;
+    width: fit-content;
 }
 
 .tab-btn {
-    background: none;
-    border: none;
-    font-size: 16px;
-    font-weight: 600;
-    color: #64748b;
-    cursor: pointer;
-    padding: 8px 4px;
-    position: relative;
-    transition: all 0.2s;
     font-family: 'Poppins', sans-serif;
 }
 
 .tab-btn:hover {
-    color: #1e293b;
+    color: inherit;
 }
 
 .tab-btn.active {
-    color: #16a34a;
-}
-
-.tab-indicator {
-    position: absolute;
-    bottom: -3px;
-    left: 0;
-    width: 100%;
-    height: 3px;
-    background: #16a34a;
-    border-radius: 3px;
-    box-shadow: 0 2px 4px rgba(22, 163, 74, 0.3);
+    color: inherit;
 }
 
 /* Feed & Posts */
@@ -550,7 +527,6 @@
         align-items: flex-start;
         padding: 24px;
         gap: 24px;
-        background: linear-gradient(135deg, #16a34a 0%, #059669 100%); /* Maintain gradient */
     }
 
     .welcome-content h1 {
@@ -599,15 +575,12 @@
     /* Tabs Scrollable */
     .content-tabs {
         overflow-x: auto;
-        padding-bottom: 8px;
         margin-bottom: 16px;
         -webkit-overflow-scrolling: touch;
-        gap: 20px;
     }
-
+    
     .tab-btn {
         white-space: nowrap;
-        font-size: 15px;
     }
 
     /* Post Card Compact */

--- a/src/pages/index/Main/index.tsx
+++ b/src/pages/index/Main/index.tsx
@@ -1,17 +1,19 @@
 import { useState, useEffect } from 'react';
-import { Modal, message, Spin, Tag, Progress } from "antd";
+import { Avatar, Modal, message, Spin, Tag, Progress } from "antd";
 import { useSelector } from "react-redux";
 import { useNavigate } from 'react-router-dom';
 import { RootState } from "../../../context/store.ts";
 import MarkDownNewEditor from "../../../components/MarkDownNewEditor.tsx";
 import { HeartOutlined, HeartFilled, StarOutlined, StarFilled, PlusOutlined, UserOutlined, ClockCircleOutlined, RightOutlined, FireOutlined, TrophyOutlined, BookOutlined, CodeOutlined } from '@ant-design/icons';
-import { createPost, thumbPost, favourPost, getMyPosts } from '../../../services/postService';
+import { createPost, thumbPost, favourPost, getAllPosts } from '../../../services/postService';
 import { getAllQuestionSets } from '../../../services/questionSetService';
 import type { PostVO } from '../../../../generated_new/post';
 import type { QuestionSetVO } from '../../../../generated_new/question';
 import { Fire, Target, ChartLine, Code, BookOpen } from '@icon-park/react';
 import Heatmap from '../../../components/Heatmap';
 import '../Posts/Posts.css';
+import MarkdownPreview from '../../../components/MarkdownPreview';
+import '../../../styles/uiuxpro.css';
 import './Main.css';
 
 const StudyPlanCard = ({ title, progress, total, icon, color }: { title: string; progress: number; total: number; icon: React.ReactNode; color: string }) => (
@@ -45,7 +47,7 @@ function OJMain() {
     const fetchPosts = async () => {
         setLoading(true);
         try {
-            const resp = await getMyPosts({ current: 1, pageSize: 5 });
+            const resp = await getAllPosts({ current: 1, pageSize: 5 });
             if (resp.code === 0 && resp.data) {
                 setPosts(resp.data.records || []);
             }
@@ -104,8 +106,25 @@ function OJMain() {
     const addTag = () => { if (tagInput.trim() && !tags.includes(tagInput.trim())) { setTags([...tags, tagInput.trim()]); setTagInput(''); } };
     const removeTag = (tag: string) => { setTags(tags.filter(t => t !== tag)); };
 
+    const stripMarkdown = (value: string) => {
+        return value
+            .replace(/```[\s\S]*?```/g, ' ')
+            .replace(/`[^`]*`/g, ' ')
+            .replace(/!\[[^\]]*]\([^)]*\)/g, ' ')
+            .replace(/\[[^\]]*]\([^)]*\)/g, ' ')
+            .replace(/[#>*_\-|~]/g, ' ')
+            .replace(/\s+/g, ' ')
+            .trim();
+    };
+
+    const getReadMinutes = (markdown?: string) => {
+        const text = stripMarkdown(markdown || '');
+        if (!text) return 1;
+        return Math.max(1, Math.round(text.length / 360));
+    };
+
     return (
-        <div className="main-container">
+        <div className="uiux-scope main-container">
             <div className="welcome-banner">
                 <div className="welcome-content">
                     <h1>欢迎回来，{currentUser?.userName || '游客朋友'}</h1>
@@ -145,11 +164,17 @@ function OJMain() {
 
             <div className="main-grid">
                 <div className="main-content">
-                    <div className="content-tabs">
+                    <div className="content-tabs uiux-tabs" role="tablist" aria-label="内容分类">
                         {tabList.map(tab => (
-                            <button key={tab} className={`tab-btn ${activeTab === tab ? 'active' : ''}`} onClick={() => setActiveTab(tab)}>
+                            <button
+                                key={tab}
+                                type="button"
+                                role="tab"
+                                aria-selected={activeTab === tab}
+                                className={`tab-btn uiux-tab ${activeTab === tab ? 'active uiux-tab-active' : ''}`}
+                                onClick={() => setActiveTab(tab)}
+                            >
                                 {tab}
-                                {activeTab === tab && <div className="tab-indicator" />}
                             </button>
                         ))}
                     </div>
@@ -157,30 +182,77 @@ function OJMain() {
                     <div className="content-feed">
                         <div className="posts-section">
                             <div className="section-header">
-                                <div className="section-title"><BookOutlined /> 我的帖子</div>
+                                <div className="section-title"><BookOutlined /> 最新帖子</div>
                                 <button className="posts-create-btn" onClick={() => setIsModalOpen(true)}><PlusOutlined /> 发布</button>
                             </div>
                             {loading ? <div className="posts-loading"><Spin size="large" /></div> : posts.length === 0 ? (
                                 <div className="posts-empty"><div className="posts-empty-icon">📝</div><div className="posts-empty-text">暂无帖子</div></div>
                             ) : posts.map((post, index) => (
-                                <div key={post.id} className="post-card">
-                                    <div className="post-header">
-                                        <h3 className="post-title" onClick={() => navigate(`/post/${post.id}`)}>{post.title}</h3>
-                                        <div className="post-meta">
-                                            <span><UserOutlined /> {post.user?.userName || '匿名'}</span>
-                                            <span><ClockCircleOutlined /> {new Date(post.createTime || '').toLocaleDateString()}</span>
+                                <div key={post.id} className="uiux-post-card uiux-card">
+                                    <div className="uiux-post-top">
+                                        <div className="uiux-post-author">
+                                            <Avatar
+                                                size={32}
+                                                src={post.user?.userAvatar}
+                                                style={{ backgroundColor: 'rgba(240, 253, 244, 1)', color: 'rgba(22, 163, 74, 1)' }}
+                                            >
+                                                {(post.user?.userName || '匿').slice(0, 1)}
+                                            </Avatar>
+                                            <div className="uiux-post-author-meta">
+                                                <div className="uiux-post-author-name">{post.user?.userName || '匿名'}</div>
+                                                <div className="uiux-post-submeta">
+                                                    <span className="uiux-post-submeta-item">
+                                                        <ClockCircleOutlined /> {new Date(post.createTime || '').toLocaleDateString()}
+                                                    </span>
+                                                    <span className="uiux-post-dot">·</span>
+                                                    <span className="uiux-post-submeta-item">{getReadMinutes(post.content)} 分钟阅读</span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div className="uiux-post-actions">
+                                            <button
+                                                className={`uiux-post-action ${post.hasThumb ? 'active' : ''}`}
+                                                onClick={() => handleThumb(index)}
+                                                type="button"
+                                                aria-label={`点赞，当前 ${post.thumbNum || 0}`}
+                                                aria-pressed={!!post.hasThumb}
+                                            >
+                                                {post.hasThumb ? <HeartFilled /> : <HeartOutlined />}
+                                                <span>{post.thumbNum || 0}</span>
+                                            </button>
+                                            <button
+                                                className={`uiux-post-action ${post.hasFavour ? 'active' : ''}`}
+                                                onClick={() => handleFavour(index)}
+                                                type="button"
+                                                aria-label={`收藏，当前 ${post.favourNum || 0}`}
+                                                aria-pressed={!!post.hasFavour}
+                                            >
+                                                {post.hasFavour ? <StarFilled /> : <StarOutlined />}
+                                                <span>{post.favourNum || 0}</span>
+                                            </button>
                                         </div>
                                     </div>
-                                    <div className="post-content">{post.content}</div>
-                                    {post.tagList && post.tagList.length > 0 && <div className="post-tags">{post.tagList.map(tag => <Tag key={tag} color="blue">{tag}</Tag>)}</div>}
-                                    <div className="post-actions">
-                                        <button className={`post-action-btn ${post.hasThumb ? 'active' : ''}`} onClick={() => handleThumb(index)}>
-                                            {post.hasThumb ? <HeartFilled /> : <HeartOutlined />}<span>{post.thumbNum || 0}</span>
-                                        </button>
-                                        <button className={`post-action-btn ${post.hasFavour ? 'active' : ''}`} onClick={() => handleFavour(index)}>
-                                            {post.hasFavour ? <StarFilled /> : <StarOutlined />}<span>{post.favourNum || 0}</span>
-                                        </button>
-                                    </div>
+
+                                    <button
+                                        type="button"
+                                        className="uiux-post-title uiux-focusable"
+                                        onClick={() => navigate(`/post/${post.id}`)}
+                                    >
+                                        {post.title}
+                                    </button>
+
+                                    <MarkdownPreview value={post.content || ''} />
+
+                                    {(post.tagList?.length || 0) > 0 && (
+                                        <div className="uiux-post-tags">
+                                            {post.tagList!.slice(0, 3).map(tag => (
+                                                <span key={tag} className="uiux-post-tag">{tag}</span>
+                                            ))}
+                                            {post.tagList!.length > 3 && (
+                                                <span className="uiux-post-tag uiux-post-tag-muted">+{post.tagList!.length - 3}</span>
+                                            )}
+                                        </div>
+                                    )}
                                 </div>
                             ))}
                         </div>

--- a/src/pages/index/Posts/Posts.css
+++ b/src/pages/index/Posts/Posts.css
@@ -9,36 +9,21 @@
 }
 
 .posts-tabs {
-  display: flex;
-  gap: 8px;
-  background: rgba(241, 245, 249, 0.85);
-  border: 1px solid rgba(226, 232, 240, 0.9);
-  border-radius: 14px;
-  padding: 6px;
   width: fit-content;
 }
 
 .posts-tab {
-  min-height: 44px;
-  padding: 10px 16px;
-  border: none;
-  background: transparent;
-  border-radius: 12px;
-  cursor: pointer;
-  font-size: 14px;
-  font-weight: 700;
-  color: var(--uiux-muted);
-  transition: background-color 160ms ease, color 160ms ease, box-shadow 160ms ease;
+  border-radius: 14px;
 }
 
 .posts-tab:hover {
-  color: var(--uiux-text);
+  color: inherit;
 }
 
 .posts-tab.active {
-  background: #ffffff;
-  color: var(--uiux-primary);
-  box-shadow: 0 8px 18px -14px rgba(15, 23, 42, 0.35);
+  background: inherit;
+  color: inherit;
+  box-shadow: none;
 }
 
 .posts-container {
@@ -64,107 +49,150 @@
   font-size: 16px;
 }
 
-.post-card {
-  padding: 20px;
+.uiux-post-card {
+  padding: 16px;
   transition: box-shadow 200ms ease, transform 200ms ease, border-color 200ms ease;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
-.post-card:hover {
+.uiux-post-card:hover {
   box-shadow: var(--uiux-shadow-md);
   transform: translateY(-1px);
   border-color: rgba(22, 163, 74, 0.22);
 }
 
-.post-header {
-  margin-bottom: 12px;
+.uiux-post-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
 }
 
-.post-title-link {
-  display: block;
-  font-size: 20px;
+.uiux-post-author {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.uiux-post-author-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.uiux-post-author-name {
   font-weight: 800;
-  margin: 0 0 8px 0;
   color: var(--uiux-text);
-  text-decoration: none;
-  line-height: 1.35;
-  letter-spacing: -0.01em;
-  word-break: break-word;
+  font-size: 14px;
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.post-title-link:hover {
-  color: var(--uiux-primary);
-  text-decoration: none;
-}
-
-.post-meta {
+.uiux-post-submeta {
   display: flex;
-  gap: 16px;
-  font-size: 13px;
+  align-items: center;
+  gap: 6px;
   color: var(--uiux-muted);
-  flex-wrap: wrap;
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.post-author,
-.post-time {
-  display: flex;
+.uiux-post-submeta-item {
+  display: inline-flex;
   align-items: center;
   gap: 4px;
 }
 
-.post-content {
-  color: rgba(71, 85, 105, 1);
-  font-size: 14px;
-  line-height: 1.6;
-  margin-bottom: 12px;
-  max-height: 104px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  line-clamp: 3;
-  -webkit-box-orient: vertical;
+.uiux-post-dot {
+  color: rgba(148, 163, 184, 1);
 }
 
-.post-tags {
-  margin-bottom: 12px;
+.uiux-post-actions {
   display: flex;
-  flex-wrap: wrap;
+  align-items: center;
   gap: 8px;
 }
 
-.post-actions {
-  display: flex;
-  gap: 12px;
-  padding-top: 12px;
-  border-top: 1px solid rgba(226, 232, 240, 0.8);
-}
-
-.post-action-btn {
-  display: flex;
+.uiux-post-action {
+  min-height: 40px;
+  padding: 0 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(226, 232, 240, 0.95);
+  background: rgba(255, 255, 255, 1);
+  cursor: pointer;
+  display: inline-flex;
   align-items: center;
   gap: 6px;
-  min-height: 44px;
-  padding: 8px 12px;
-  border: 1px solid rgba(226, 232, 240, 0.95);
-  background: #ffffff;
-  border-radius: 12px;
-  cursor: pointer;
-  font-size: 14px;
+  font-weight: 800;
+  font-size: 13px;
   color: rgba(71, 85, 105, 1);
   transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease;
-  font-weight: 700;
 }
 
-.post-action-btn:hover {
+.uiux-post-action:hover {
   border-color: rgba(22, 163, 74, 0.35);
   color: var(--uiux-primary);
   background: rgba(240, 253, 244, 0.8);
 }
 
-.post-action-btn.active {
+.uiux-post-action.active {
   border-color: rgba(239, 68, 68, 0.35);
   color: #ef4444;
   background: rgba(254, 242, 242, 1);
+}
+
+.uiux-post-title {
+  display: block;
+  color: var(--uiux-text);
+  text-decoration: none;
+  font-size: 18px;
+  font-weight: 900;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+  margin-top: 2px;
+  word-break: break-word;
+  background: transparent;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.uiux-post-title:hover {
+  color: var(--uiux-primary);
+  text-decoration: none;
+}
+
+.uiux-post-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-top: 2px;
+}
+
+.uiux-post-tag {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  padding: 0 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(226, 232, 240, 0.95);
+  background: rgba(241, 245, 249, 0.7);
+  color: rgba(30, 41, 59, 1);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.uiux-post-tag-muted {
+  color: var(--uiux-muted);
 }
 
 .posts-pagination {

--- a/src/pages/index/QuestionSets/QuestionSets.css
+++ b/src/pages/index/QuestionSets/QuestionSets.css
@@ -14,36 +14,21 @@
 }
 
 .qs-tabs {
-  display: flex;
-  gap: 8px;
-  background: rgba(241, 245, 249, 0.85);
-  border: 1px solid rgba(226, 232, 240, 0.9);
-  border-radius: 14px;
-  padding: 6px;
   width: fit-content;
 }
 
 .qs-tab {
-  min-height: 44px;
-  padding: 10px 16px;
-  border: none;
-  background: transparent;
-  border-radius: 12px;
-  cursor: pointer;
-  font-size: 14px;
-  font-weight: 800;
-  color: var(--uiux-muted);
-  transition: background-color 160ms ease, color 160ms ease, box-shadow 160ms ease;
+  border-radius: 14px;
 }
 
 .qs-tab:hover {
-  color: var(--uiux-text);
+  color: inherit;
 }
 
 .qs-tab.active {
-  background: #ffffff;
-  color: var(--uiux-primary);
-  box-shadow: 0 8px 18px -14px rgba(15, 23, 42, 0.35);
+  background: inherit;
+  color: inherit;
+  box-shadow: none;
 }
 
 .qs-header-actions {

--- a/src/pages/index/QuestionSets/index.tsx
+++ b/src/pages/index/QuestionSets/index.tsx
@@ -135,12 +135,12 @@ const QuestionSets: React.FC = () => {
       </div>
 
       <div className="qs-toolbar uiux-card">
-        <div className="qs-tabs" role="tablist" aria-label="题单视图">
+        <div className="qs-tabs uiux-tabs" role="tablist" aria-label="题单视图">
           <button
             type="button"
             role="tab"
             aria-selected={viewMode === 'my'}
-            className={`qs-tab ${viewMode === 'my' ? 'active' : ''}`}
+            className={`qs-tab uiux-tab ${viewMode === 'my' ? 'active uiux-tab-active' : ''}`}
             onClick={() => {
               setViewMode('my');
               setCurrentPage(1);
@@ -152,7 +152,7 @@ const QuestionSets: React.FC = () => {
             type="button"
             role="tab"
             aria-selected={viewMode === 'all'}
-            className={`qs-tab ${viewMode === 'all' ? 'active' : ''}`}
+            className={`qs-tab uiux-tab ${viewMode === 'all' ? 'active uiux-tab-active' : ''}`}
             onClick={() => {
               setViewMode('all');
               setCurrentPage(1);

--- a/src/pages/index/Questions/Questions.css
+++ b/src/pages/index/Questions/Questions.css
@@ -29,35 +29,21 @@
 }
 
 .qs-chips {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
+  width: 100%;
 }
 
 .qs-chip {
-  min-height: 44px;
-  padding: 10px 14px;
-  background: rgba(241, 245, 249, 0.65);
-  border: 1px solid rgba(226, 232, 240, 0.9);
-  color: var(--uiux-text);
-  border-radius: 999px;
-  font-size: 13px;
-  cursor: pointer;
-  transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease, box-shadow 160ms ease;
-  font-weight: 800;
+  border-radius: 14px;
 }
 
 .qs-chip:hover {
-  border-color: rgba(22, 163, 74, 0.32);
-  color: var(--uiux-primary);
-  background: rgba(240, 253, 244, 0.85);
+  color: inherit;
 }
 
 .qs-chip.qs-active {
-  background: var(--uiux-primary);
-  color: #ffffff;
-  border-color: transparent;
-  box-shadow: 0 10px 22px -18px rgba(22, 163, 74, 0.85);
+  background: inherit;
+  color: inherit;
+  box-shadow: none;
 }
 
 .qs-question-panel {
@@ -283,7 +269,7 @@
 
 .qb-hero-icon {
   font-size: 42px;
-  color: rgba(255, 255, 255, 0.92);
+  color: var(--uiux-primary);
 }
 
 .uiux-questionbank-page .custom-tree .ant-tree-node-selected {

--- a/src/pages/index/Questions/index.tsx
+++ b/src/pages/index/Questions/index.tsx
@@ -217,11 +217,13 @@ const Questions: React.FC = () => {
           <div className="qs-stat-item"><span className="qs-badge-dot"></span><strong>题目总数</strong> {questions.length}</div>
           <div className="qs-stat-item"><strong>已筛选</strong> {filteredQuestions.length}</div>
         </div>
-        <div className="qs-chips">
+        <div className="qs-chips uiux-tabs uiux-tabs-wrap" role="tablist" aria-label="题目分类">
           <button
             type="button"
-            className={`qs-chip ${activeCategory === '全部' ? 'qs-active' : ''}`}
+            className={`qs-chip uiux-tab ${activeCategory === '全部' ? 'qs-active uiux-tab-active' : ''}`}
             onClick={() => setActiveCategory('全部')}
+            role="tab"
+            aria-selected={activeCategory === '全部'}
           >
             全部
           </button>
@@ -229,8 +231,10 @@ const Questions: React.FC = () => {
             <button
               type="button"
               key={tag}
-              className={`qs-chip ${activeCategory === tag ? 'qs-active' : ''}`}
+              className={`qs-chip uiux-tab ${activeCategory === tag ? 'qs-active uiux-tab-active' : ''}`}
               onClick={() => setActiveCategory(tag)}
+              role="tab"
+              aria-selected={activeCategory === tag}
             >
               {tag}
             </button>

--- a/src/pages/room/MyRooms/index.css
+++ b/src/pages/room/MyRooms/index.css
@@ -53,7 +53,10 @@
 
 .room-card-header {
   height: 80px;
-  background: var(--uiux-gradient);
+  background:
+    radial-gradient(160px 70px at 25% 20%, rgba(22, 163, 74, 0.28), rgba(22, 163, 74, 0) 70%),
+    radial-gradient(220px 90px at 85% 140%, rgba(5, 150, 105, 0.18), rgba(5, 150, 105, 0) 60%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(248, 250, 252, 0.92));
   display: flex;
   justify-content: flex-end;
   align-items: flex-start;

--- a/src/pages/room/RoomList/index.css
+++ b/src/pages/room/RoomList/index.css
@@ -29,11 +29,15 @@
 
 .room-card-header {
   height: 80px;
-  background: var(--uiux-gradient);
+  background:
+    radial-gradient(160px 70px at 25% 20%, rgba(22, 163, 74, 0.28), rgba(22, 163, 74, 0) 70%),
+    radial-gradient(220px 90px at 85% 140%, rgba(5, 150, 105, 0.18), rgba(5, 150, 105, 0) 60%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(248, 250, 252, 0.92));
   display: flex;
   justify-content: flex-end;
   align-items: flex-start;
   padding: 16px;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.85);
 }
 
 .room-status {

--- a/src/styles/uiuxpro.css
+++ b/src/styles/uiuxpro.css
@@ -1,4 +1,9 @@
+@import url("https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap");
+
 .uiux-scope {
+  --uiux-font-sans: "Plus Jakarta Sans", ui-sans-serif, system-ui, -apple-system, "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";
+  --uiux-font-display: "Space Grotesk", "Plus Jakarta Sans", ui-sans-serif, system-ui, -apple-system, "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";
+  font-family: var(--uiux-font-sans);
   --uiux-primary: #16a34a;
   --uiux-primary-hover: #15803d;
   --uiux-primary-active: #166534;
@@ -24,37 +29,35 @@
 }
 
 .uiux-hero {
-  background: var(--uiux-gradient);
+  background:
+    radial-gradient(180px 90px at 20% 15%, rgba(22, 163, 74, 0.18), rgba(22, 163, 74, 0) 70%),
+    radial-gradient(220px 110px at 85% 140%, rgba(5, 150, 105, 0.14), rgba(5, 150, 105, 0) 60%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(248, 250, 252, 0.92));
   border-radius: var(--uiux-radius-xl);
   padding: 28px;
-  color: #ffffff;
-  box-shadow: 0 10px 30px -14px rgba(22, 163, 74, 0.45);
+  color: var(--uiux-text);
+  box-shadow: 0 10px 30px -18px rgba(15, 23, 42, 0.22);
   position: relative;
   overflow: hidden;
+  border: 1px solid rgba(226, 232, 240, 0.9);
 }
 
 .uiux-hero::before {
   content: "";
   position: absolute;
-  top: -60%;
-  left: -20%;
-  width: 220px;
-  height: 220px;
-  background: rgba(255, 255, 255, 0.14);
-  border-radius: 50%;
-  filter: blur(55px);
+  inset: 0;
+  background:
+    repeating-linear-gradient(135deg, rgba(22, 163, 74, 0.06) 0 6px, rgba(22, 163, 74, 0) 6px 12px);
+  opacity: 0.85;
+  pointer-events: none;
 }
 
 .uiux-hero::after {
   content: "";
   position: absolute;
-  bottom: -70%;
-  right: -20%;
-  width: 320px;
-  height: 320px;
-  background: rgba(255, 255, 255, 0.12);
-  border-radius: 50%;
-  filter: blur(70px);
+  inset: 0;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85);
+  pointer-events: none;
 }
 
 .uiux-hero-inner {
@@ -68,18 +71,19 @@
 }
 
 .uiux-hero-title {
+  font-family: var(--uiux-font-display);
   font-size: 28px;
   line-height: 1.2;
-  font-weight: 800;
+  font-weight: 950;
   letter-spacing: -0.02em;
   margin: 0 0 8px 0;
-  color: #ffffff;
+  color: var(--uiux-text);
 }
 
 .uiux-hero-subtitle {
   margin: 0;
-  opacity: 0.95;
-  color: rgba(255, 255, 255, 0.92);
+  opacity: 1;
+  color: rgba(71, 85, 105, 1);
   font-size: 14px;
   line-height: 1.6;
   font-weight: 500;
@@ -91,6 +95,238 @@
   border: 1px solid rgba(226, 232, 240, 0.9);
   border-radius: var(--uiux-radius-lg);
   box-shadow: var(--uiux-shadow-sm);
+}
+
+.uiux-tabs {
+  display: flex;
+  gap: 8px;
+  background: rgba(241, 245, 249, 0.75);
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  border-radius: 16px;
+  padding: 6px;
+  width: fit-content;
+}
+
+.uiux-tabs-wrap {
+  width: 100%;
+  flex-wrap: wrap;
+}
+
+.uiux-navbar {
+  background: rgba(255, 255, 255, 0.78) !important;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.9);
+  backdrop-filter: blur(12px);
+  position: relative;
+}
+
+.uiux-navbar::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(220px 90px at 12% 20%, rgba(22, 163, 74, 0.10), rgba(22, 163, 74, 0) 70%),
+    repeating-linear-gradient(135deg, rgba(22, 163, 74, 0.03) 0 8px, rgba(22, 163, 74, 0) 8px 16px);
+  pointer-events: none;
+  opacity: 0.9;
+}
+
+.uiux-navbar-inner {
+  max-width: 1280px;
+  margin: 0 auto;
+  width: 100%;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 16px;
+  position: relative;
+  z-index: 1;
+}
+
+.uiux-navbar-logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-right: 4px;
+  padding: 8px 10px;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  background: transparent;
+  cursor: pointer;
+  transition: background-color 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+  min-height: 44px;
+}
+
+.uiux-navbar-logo:hover {
+  background: rgba(241, 245, 249, 0.75);
+  border-color: rgba(226, 232, 240, 0.95);
+}
+
+.uiux-navbar-logo img {
+  display: block;
+}
+
+.uiux-navbar-brand {
+  font-family: var(--uiux-font-display);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--uiux-text);
+  line-height: 1;
+  font-size: 16px;
+}
+
+.uiux-navbar-nav {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  padding: 0;
+  gap: 6px;
+}
+
+.uiux-navbar-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 44px;
+  padding: 8px 12px;
+  border: 1px solid transparent;
+  background: transparent;
+}
+
+.uiux-navbar-tab:hover {
+  background: rgba(241, 245, 249, 0.75);
+  border-color: rgba(226, 232, 240, 0.95);
+}
+
+.uiux-navbar-tab.uiux-tab-active {
+  border-color: transparent;
+  box-shadow: 0 10px 22px -20px rgba(15, 23, 42, 0.50), 0 10px 22px -18px rgba(22, 163, 74, 0.78);
+}
+
+.uiux-navbar-tab-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+}
+
+.uiux-navbar-tab-icon svg {
+  width: 18px;
+  height: 18px;
+}
+
+.uiux-navbar-user {
+  display: flex;
+  align-items: center;
+  padding: 6px 8px;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  transition: background-color 160ms ease, border-color 160ms ease;
+  min-height: 44px;
+}
+
+.uiux-navbar-user:hover {
+  background: rgba(241, 245, 249, 0.75);
+  border-color: rgba(226, 232, 240, 0.95);
+}
+
+@media (max-width: 860px) {
+  .uiux-navbar-brand {
+    display: none;
+  }
+}
+
+.uiux-tab {
+  min-height: 44px;
+  padding: 10px 16px;
+  border: none;
+  background: transparent;
+  border-radius: 14px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 900;
+  color: var(--uiux-muted);
+  position: relative;
+  transition: background-color 160ms ease, color 160ms ease, box-shadow 160ms ease;
+  letter-spacing: -0.01em;
+}
+
+.uiux-tab:hover {
+  color: var(--uiux-text);
+}
+
+.uiux-tab-active {
+  color: #ffffff;
+  background: var(--uiux-gradient);
+  box-shadow: 0 12px 28px -22px rgba(15, 23, 42, 0.55), 0 10px 22px -18px rgba(22, 163, 74, 0.85);
+  overflow: hidden;
+}
+
+.uiux-tab-active::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(120px 60px at 25% 10%, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0) 70%),
+    radial-gradient(140px 70px at 80% 120%, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0) 65%),
+    repeating-linear-gradient(135deg, rgba(255, 255, 255, 0.10) 0 6px, rgba(255, 255, 255, 0) 6px 12px);
+  opacity: 0.95;
+  pointer-events: none;
+}
+
+.uiux-tab-active::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
+  pointer-events: none;
+}
+
+.uiux-tab span,
+.uiux-tab svg {
+  position: relative;
+  z-index: 1;
+}
+
+.uiux-md-preview {
+  color: rgba(71, 85, 105, 1);
+  font-size: 14px;
+  line-height: 1.6;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+}
+
+.uiux-md-preview .uiux-md-block {
+  margin: 0;
+}
+
+.uiux-md-preview .uiux-md-heading {
+  font-weight: 800;
+  color: rgba(15, 23, 42, 1);
+}
+
+.uiux-md-preview .uiux-md-list {
+  padding-left: 0;
+  list-style: none;
+}
+
+.uiux-md-preview .uiux-md-li::before {
+  content: "• ";
+  color: rgba(100, 116, 139, 1);
+}
+
+.uiux-md-preview .uiux-md-code {
+  background: rgba(241, 245, 249, 1);
+  border: 1px solid rgba(226, 232, 240, 1);
+  border-radius: 8px;
+  padding: 1px 6px;
+  color: rgba(15, 23, 42, 1);
+  font-weight: 700;
+  font-size: 12px;
 }
 
 .uiux-scope .ant-btn {


### PR DESCRIPTION
- 提取标签页样式到全局 `uiuxpro.css`，提供 `.uiux-tabs` 和 `.uiux-tab` 通用类
- 在帖子、题单、题目分类、主页面板等多个组件中应用统一标签页样式
- 优化房间卡片头部背景，使用多层径向渐变替代单一渐变
- 更新欢迎横幅和英雄区域视觉设计，采用更现代的玻璃态效果
- 移除各组件冗余的标签页样式代码，提高样式可维护性